### PR TITLE
Replay.GetPlayerById was incorrectly testing the player ID for "out of bounds"

### DIFF
--- a/Starcraft2.ReplayParser/Replay.cs
+++ b/Starcraft2.ReplayParser/Replay.cs
@@ -70,7 +70,7 @@ namespace Starcraft2.ReplayParser
         {
             int playerIndex = playerId - 1;
 
-            if (playerId < this.Players.Length)
+            if (playerIndex < this.Players.Length)
             {
                 return this.Players[playerIndex];
             }


### PR DESCRIPTION
GetPlayerById was incorrectly testing the player ID for "out of bounds" issues, rather than the playerIndex, so trying to get the last player in the Players array would return null instead.
