### PR TITLE
Added parsing of map gateway and hash. 

### DIFF
--- a/Starcraft2.ReplayParser/Replay.cs
+++ b/Starcraft2.ReplayParser/Replay.cs
@@ -47,6 +47,12 @@ namespace Starcraft2.ReplayParser
         /// <summary> Gets the map the game was played on. </summary>
         public string Map { get; internal set; }
 
+		public string MapPreviewName { get; internal set; }
+
+		public string MapGateway { get; internal set; }
+
+		public byte[] MapHash { get; internal set; }
+
         /// <summary> Gets the list of game events occuring during the course of the replay. </summary>
         public List<IGameEvent> PlayerEvents { get; internal set; }
 


### PR DESCRIPTION
With the gateway and hash of the map, you can access the actual map file via the following url template:

http://{gateway}.depot.battle.net:1119/{lowercase-hex-encoded-hash}.s2ma

For example, Metalopolis can be found at http://us.depot.battle.net:1119/cadd112e2aca3ed743863b669bb869ce86cdce3ad6171087b8182abe4ac8e9cd.s2ma

This information allows users of the replay parser to download the map file associated with the replay, to do things like e.g. display a minimap image.
