### PR TITLE
Bug fixes, 0x38 event

### DIFF
--- a/Starcraft2.ReplayParser/replay.game.events/AbilityEvent.cs
+++ b/Starcraft2.ReplayParser/replay.game.events/AbilityEvent.cs
@@ -112,7 +112,7 @@ namespace Starcraft2.ReplayParser
                 }
 
                 // 1.4.0 -- Don't really know what this was meant to fix
-                if (replay.ReplayBuild >= 19679)
+                if (replay.ReplayBuild >= 19595)
                 {
                     var targetHasTeam = bitReader.Read(1) == 1;
                     if (targetHasTeam)

--- a/Starcraft2.ReplayParser/replay.game.events/HotkeyEvent.cs
+++ b/Starcraft2.ReplayParser/replay.game.events/HotkeyEvent.cs
@@ -109,7 +109,10 @@ namespace Starcraft2.ReplayParser
 
                 foreach (Unit unit in player.Wireframe)
                 {
-                    newControlgroup.Add(unit);
+                    if (!oldControlgroup.Contains(unit))
+                    {
+                        newControlgroup.Add(unit);
+                    }
                 }
                 newControlgroup.Sort((m, n) => m.Id - n.Id);
 

--- a/Starcraft2.ReplayParser/replay.game.events/ReplayGameEvents.cs
+++ b/Starcraft2.ReplayParser/replay.game.events/ReplayGameEvents.cs
@@ -115,6 +115,20 @@
                             bitReader.Read(32);
                             bitReader.Read(32);
                             break;
+                        case 0x38: // weird sync event
+                            {
+                                gameEvent = new GameEventBase();
+                                gameEvent.EventType = GameEventType.Other;
+                                for (var j = 0; j < 2; j++)
+                                {
+                                    var length = bitReader.Read(8);
+                                    for (var i = 0; i < length; i++)
+                                    {
+                                        bitReader.Read(32);
+                                    }
+                                }
+                                break;
+                            }
                         case 0x3c: // ???
                             gameEvent = new GameEventBase();
                             gameEvent.EventType = GameEventType.Inactive;


### PR DESCRIPTION
Updated the wiki as well.

---

Pro-tip:  A list is not a set, and if you treat a list like a set you
end up with a 0x50000 length list.

Special thanks to @GraylinKim for his data in helping me find 0x38, the
aforementioned bug, and a more accurate 1.4.0 build number.
